### PR TITLE
README: Update helm repo url to Scala Steward gh-pages url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,11 @@
-# The Garner Helm Chart Library
+# The Scala Steward Helm Chart Library
 
-Applications provided by [Garner](https://garnercorp.io) ready to launch on [Kubernetes](https://kubernetes.io)
+Applications provided by Scala Steward org ready to launch on [Kubernetes](https://kubernetes.io)
 using [Helm](https://helm.sh).
 
 ## Usage
 ```sh
-helm repo add garnercorp https://garnercorp.github.io/charts
-helm search repo garnercorp
-helm install my-release garnercorp/<chart>
+helm repo add scala-steward-org https://scala-steward-org.github.io/charts
+helm search repo scala-steward-org
+helm install my-release scala-steward-org/<chart>
 ```
-
-# License
-
-Copyright (c) 2020 Garner Distributed Workflow Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ helm repo add scala-steward-org https://scala-steward-org.github.io/charts
 helm search repo scala-steward-org
 helm install my-release scala-steward-org/<chart>
 ```
+
+# License
+
+Copyright (c) 2020 Garner Distributed Workflow Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/scala-steward/README.md
+++ b/charts/scala-steward/README.md
@@ -5,5 +5,6 @@
 ## TL;DR;
 
 ```sh
-helm install my-release garnercorp/scala-steward
+helm repo add scala-steward-org https://scala-steward-org.github.io/charts
+helm install my-release scala-steward-org/scala-steward
 ```


### PR DESCRIPTION
Fixing README so it reflects the new URL (after the move of this repo into scala-steward-org in #3).