### PR TITLE
add option to add files in container

### DIFF
--- a/charts/scala-steward/Chart.yaml
+++ b/charts/scala-steward/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: scala-steward
 type: application
-version: 0.2.3
+version: 0.3.0
 appVersion: 0.30.2
 description: A Helm chart for scala-steward
 keywords:

--- a/charts/scala-steward/Chart.yaml
+++ b/charts/scala-steward/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scala-steward
 type: application
 version: 0.2.3
-appVersion: 0.5.0
+appVersion: 0.30.2
 description: A Helm chart for scala-steward
 keywords:
   - scala

--- a/charts/scala-steward/templates/configmap.yaml
+++ b/charts/scala-steward/templates/configmap.yaml
@@ -11,3 +11,15 @@ data:
     {{- tpl (.Files.Get "files/password.sh") . | nindent 4 }}
   scalafix.conf: |
     {{- .Values.scalafixConfig | nindent 4 }}
+{{- if .Values.additionalFiles }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "scala-steward.fullname" . }}-files
+data:
+  {{- range $k, $v := .Values.additionalFiles }}
+  {{ $k }}:
+    {{ $v.content | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/scala-steward/templates/cron-job.yaml
+++ b/charts/scala-steward/templates/cron-job.yaml
@@ -43,6 +43,11 @@ spec:
                 name: opt
               - mountPath: /var/scala-steward/workspace
                 name: workspace
+              {{- range $k, $v := .Values.additionalFiles }}
+              - mountPath: {{ $v.path }}
+                name: files
+                subPath: {{ $k }}
+              {{- end }}
           volumes:
             - name: opt
               configMap:
@@ -62,4 +67,14 @@ spec:
             {{- else }}
             - name: workspace
               emptyDir: {}
+            {{- end }}
+            {{- if .Values.additionalFiles }}
+            - name: files
+              configMap:
+                name: {{ include "scala-steward.fullname" . }}-files
+                items:
+                {{- range $k, $v := .Values.additionalFiles }}
+                  - key: {{ $k }}
+                    path: {{ $k }}
+                {{- end }}
             {{- end }}

--- a/charts/scala-steward/values.yaml
+++ b/charts/scala-steward/values.yaml
@@ -53,3 +53,11 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 5Gi
+
+additionalFiles: {}
+# this can be used to make files available in the container, e. g. for authentication for an artifact repository
+# additionalFiles:
+#   nexusCredentials:
+#     path: /root/.sbt/1.0/credentials.sbt
+#     content: |
+#       credentials += Credentials(sys.env("NEXUS_REALM"), sys.env("NEXUS_HOST"), sys.env("NEXUS_USERNAME"), sys.env("NEXUS_PASSWORD"))

--- a/charts/scala-steward/values.yaml
+++ b/charts/scala-steward/values.yaml
@@ -3,7 +3,7 @@ scalaStewardArgs:
   - /var/scala-steward/workspace
   - --repos-file
   - /opt/scala-steward/repos.md
-  - --vcs-api-host
+  - --forge-api-host
   - https://api.github.com
   - --git-ask-pass
   - /opt/scala-steward/password.sh
@@ -14,7 +14,7 @@ scalaStewardArgs:
 additionalScalaStewardArgs:
   - --git-author-email
   - MY_EMAIL
-  - --vcs-login
+  - --forge-login
   - MY_LOGIN
 
 additionalScalaStewardEnvs: {}
@@ -27,7 +27,7 @@ gitSecret: ""
 existingGitSecretName: ""
 
 image:
-  tag: 0.5.0-460-aad4fc41-SNAPSHOT
+  tag: 0.30.2
   repository: fthomas/scala-steward
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Hi,

I've added the possibility to add files that will be mounted into the scala-steward container. I needed this for two things:
 - for use with the `--repo-config` option which requires a file. I could of course put this into each individual repo, but I want to be able to configure it the same way across repos
 - for the `/root/.sbt/1.0/credentials.sbt` file where I read the Nexus credentials from the env variables. again, I don't want to modify lots of different repos to do this.

Let me know what you think. 